### PR TITLE
feat: add validation form from create-page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,9 @@
-import { Route, Routes } from 'react-router-dom';
+import {
+  createBrowserRouter,
+  Route,
+  RouterProvider,
+  Routes,
+} from 'react-router-dom';
 import { Layout } from './components/Layout';
 import { AboutPage } from './pages/AboutPage';
 import { ErrorPage } from './pages/ErrorPage';
@@ -8,6 +13,38 @@ import 'primereact/resources/themes/lara-light-indigo/theme.css';
 import 'primereact/resources/primereact.min.css';
 import 'primeicons/primeicons.css';
 import { RegistrationPage } from './pages/RegistrationPage';
+
+// const router = createBrowserRouter([
+//   {
+//     path: '/',
+//     element: <Layout />,
+//     errorElement: <ErrorPage />,
+//     children: [
+//       {
+//         path: '/',
+//         element: <MainPage />,
+//       },
+//       {
+//         path: 'signin',
+//         element: <SignInPage />,
+//         children: [
+//           {
+//             path: 'registration',
+//             element: <RegistrationPage />,
+//           },
+//         ],
+//       },
+//       {
+//         path: 'about',
+//         element: <AboutPage />,
+//       },
+//     ],
+//   },
+// ]);
+
+// const App = (): React.ReactElement => {
+//   return <RouterProvider router={router} />;
+// };
 
 function App(): JSX.Element {
   return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,4 @@
-import {
-  createBrowserRouter,
-  Route,
-  RouterProvider,
-  Routes,
-} from 'react-router-dom';
+import { Route, Routes } from 'react-router-dom';
 import { Layout } from './components/Layout';
 import { AboutPage } from './pages/AboutPage';
 import { ErrorPage } from './pages/ErrorPage';
@@ -13,38 +8,6 @@ import 'primereact/resources/themes/lara-light-indigo/theme.css';
 import 'primereact/resources/primereact.min.css';
 import 'primeicons/primeicons.css';
 import { RegistrationPage } from './pages/RegistrationPage';
-
-// const router = createBrowserRouter([
-//   {
-//     path: '/',
-//     element: <Layout />,
-//     errorElement: <ErrorPage />,
-//     children: [
-//       {
-//         path: '/',
-//         element: <MainPage />,
-//       },
-//       {
-//         path: 'signin',
-//         element: <SignInPage />,
-//         children: [
-//           {
-//             path: 'registration',
-//             element: <RegistrationPage />,
-//           },
-//         ],
-//       },
-//       {
-//         path: 'about',
-//         element: <AboutPage />,
-//       },
-//     ],
-//   },
-// ]);
-
-// const App = (): React.ReactElement => {
-//   return <RouterProvider router={router} />;
-// };
 
 function App(): JSX.Element {
   return (

--- a/src/api/Client.ts
+++ b/src/api/Client.ts
@@ -1,18 +1,22 @@
 import { ctpClient } from './BuildClient';
 import {
-  ApiRoot,
   createApiBuilderFromCtpClient,
+  CustomerSignin,
+  CustomerSignInResult,
 } from '@commercetools/platform-sdk';
+import { ApiRequest } from '@commercetools/platform-sdk/dist/declarations/src/generated/shared/utils/requests-utils';
 
 // Create apiRoot from the imported ClientBuilder and include your Project key
 const apiRoot = createApiBuilderFromCtpClient(ctpClient).withProjectKey({
   projectKey: 'bon747jour',
 });
 
-// Example call to return Project information
-// This code has the same effect as sending a GET request to the commercetools Composable Commerce API without any endpoints.
-export const getProject = (): Promise<Object> => {
+export const getClients = (): Promise<Object> => {
   return apiRoot.get().execute();
 };
 
-getProject().then(console.log).catch(console.error);
+export const clientSignIn = (
+  data: CustomerSignin,
+): ApiRequest<CustomerSignInResult> => {
+  return apiRoot.login().post({ body: data });
+};

--- a/src/interface/interface.ts
+++ b/src/interface/interface.ts
@@ -1,0 +1,4 @@
+export interface SignInForm {
+  email: string;
+  password: string;
+}

--- a/src/pages/SignInPage.tsx
+++ b/src/pages/SignInPage.tsx
@@ -1,40 +1,93 @@
 import { FieldValues, useForm } from 'react-hook-form';
 import { InputText } from 'primereact/inputtext';
 import { Button } from 'primereact/button';
+import { Message } from 'primereact/message';
 
 export const SignInPage = (): JSX.Element => {
-  const { register, handleSubmit } = useForm();
-  const onSubmit = (data: FieldValues): void =>
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isValid },
+    reset,
+  } = useForm({
+    mode: 'onBlur',
+  });
+  const onSubmit = (data: FieldValues): void => {
     console.log(JSON.stringify(data));
+    reset();
+  };
 
   return (
     <div className="registration__page content">
       <form onSubmit={handleSubmit(onSubmit)} className="flex flex-column">
         <InputText
-          className="mb-5"
-          {...register('email')}
-          type="email"
+          className="mb-1"
+          {...register('email', {
+            required: 'Required to fill',
+            minLength: {
+              value: 5,
+              message: 'Minimum 5 characters',
+            },
+            pattern: {
+              value:
+                // eslint-disable-next-line no-useless-escape
+                /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
+              message: 'Incorrect email',
+            },
+          })}
+          type="text"
           placeholder="Enter your email"
         />
+        <Message
+          className={
+            ((errors?.email?.message as string) && 'h-1rem') || 'hidden'
+          }
+          severity={'error'}
+          text={errors?.email?.message as string}
+        />
+
         <InputText
-          className="mb-5"
-          {...register('password')}
+          className="mt-5 mb-1"
+          {...register('password', {
+            required: 'Required to fill',
+            minLength: {
+              value: 8,
+              message: 'Minimum 8 characters',
+            },
+            maxLength: {
+              value: 20,
+              message: 'Maximum 20 characters',
+            },
+          })}
           type="password"
           placeholder="Enter your password"
           autoComplete="on"
         />
-        <Button className="mb-7" label="Sign In" type="submit" disabled />
+        <Message
+          className={
+            ((errors?.password?.message as string) && 'h-1rem') || 'hidden'
+          }
+          severity={'error'}
+          text={errors?.password?.message as string}
+        />
+
+        <Button
+          className="mt-6 mb-5"
+          label="Sign In"
+          type="submit"
+          disabled={!isValid}
+        />
       </form>
+
       <h4 className="center mb-2 pl-2 pr-2 text-center">
         If you are not registered, please register in our store.
       </h4>
+
       <Button
         className="mt-3 mb-8"
         label="Registration"
         type="button"
-        onClick={(): void => {
-          console.log('click');
-        }}
+        onClick={(e): void => console.log(e.nativeEvent)}
       />
     </div>
   );

--- a/src/pages/SignInPage.tsx
+++ b/src/pages/SignInPage.tsx
@@ -1,20 +1,33 @@
-import { FieldValues, useForm } from 'react-hook-form';
+import { SubmitHandler, useForm } from 'react-hook-form';
 import { InputText } from 'primereact/inputtext';
 import { Button } from 'primereact/button';
 import { Message } from 'primereact/message';
+import { clientSignIn } from '../api/Client';
+import { SignInForm } from '../interface/interface';
+import { useNavigate } from 'react-router-dom';
 
 export const SignInPage = (): JSX.Element => {
   const {
     register,
     handleSubmit,
+    setError,
     formState: { errors, isValid },
-    reset,
-  } = useForm({
+  } = useForm<SignInForm>({
     mode: 'onBlur',
   });
-  const onSubmit = (data: FieldValues): void => {
-    console.log(JSON.stringify(data));
-    reset();
+
+  const toRegistrationForm = useNavigate();
+
+  const onSubmit: SubmitHandler<SignInForm> = (data): void => {
+    clientSignIn(data)
+      .execute()
+      .then(data => console.log(data))
+      .catch(() =>
+        setError('email', {
+          type: 'manual',
+          message: 'Email or password is incorrect',
+        }),
+      );
   };
 
   return (
@@ -30,7 +43,6 @@ export const SignInPage = (): JSX.Element => {
             },
             pattern: {
               value:
-                // eslint-disable-next-line no-useless-escape
                 /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
               message: 'Incorrect email',
             },
@@ -51,7 +63,7 @@ export const SignInPage = (): JSX.Element => {
           {...register('password', {
             required: 'Required to fill',
             minLength: {
-              value: 8,
+              value: 4,
               message: 'Minimum 8 characters',
             },
             maxLength: {
@@ -87,7 +99,7 @@ export const SignInPage = (): JSX.Element => {
         className="mt-3 mb-8"
         label="Registration"
         type="button"
-        onClick={(e): void => console.log(e.nativeEvent)}
+        onClick={(): void => toRegistrationForm('/registration')}
       />
     </div>
   );


### PR DESCRIPTION
For Login Page:

 - Implement client-side validation for the login form, including email and password fields.
 - Display clear error messages indicating any validation issues, such as an improperly formatted email.
 - add a data validation form on the server
