### PR TITLE
fix: change asyncCartDeleteID to asyncDeleteAllProductForCartID

### DIFF
--- a/src/components/Cart/CartList.tsx
+++ b/src/components/Cart/CartList.tsx
@@ -9,7 +9,7 @@ import { useCartID } from './useCart';
 import ItemsVision from './ItemsVision';
 import { FIRST_INDEX } from '../../constants/common';
 import CartEmpty from './CartEmpty';
-import { asyncCartDeleteID } from './useItemCart';
+import { asyncDeleteAllProductForCartID } from './useItemCart';
 import { ConfirmPopup } from 'primereact/confirmpopup';
 import { Toast } from 'primereact/toast';
 import { Dialog } from 'primereact/dialog';
@@ -50,7 +50,7 @@ export default function CartList(props: { onOffForm: object }): JSX.Element {
 
   const accept = (): void => {
     setTimeout((): void => {
-      asyncCartDeleteID(editData);
+      asyncDeleteAllProductForCartID(editData);
       count.cartID = '';
       count.versionCart = 1;
     }, 2000);
@@ -155,7 +155,7 @@ export default function CartList(props: { onOffForm: object }): JSX.Element {
           //=====================Запуск запросов для проверок и корректировок=========
           //==========cartDeleteID
           // (async (): Promise<void> => {
-          //   await cartDeleteID('f5134eb5-fbcd-4ccf-95d1-a9090a6812dc', 12) // версия в удаляемой корзине
+          //   await cartDeleteID('b7de7a62-0b93-4745-aa68-ab6ce21ec3ee', 13) // версия в удаляемой корзине
           //     .then(({ body }) => {
           //       console.log(body);
           //       console.log('444444');

--- a/src/components/DisplayProductInfo/DisplayProductInfo.tsx
+++ b/src/components/DisplayProductInfo/DisplayProductInfo.tsx
@@ -46,19 +46,14 @@ export function DisplayProductInfo(keyProduct: string): JSX.Element {
   //=========
   const [checked, setChecked] = useState<boolean>(false);
   //ну и эту тоже в добавок
-  const [visibleError, setVisibleError] = useState<boolean>(false);
+  // const [visibleError, setVisibleError] = useState<boolean>(false);
   const cartIsItem = useIsItemInCart(keyProduct);
   useEffect(() => {
     setChecked(cartIsItem.IsItem);
   }, [cartIsItem.IsItem]);
 
   // эту тоже функцию надо будет выпилить)
-  const callback = (delet: boolean, sumaItem: number): void => {
-    if (delet) {
-      setVisibleError(true);
-    }
-    setChecked(delet);
-  };
+  const callback = (): void => {};
 
   const messagePopUp = useRef<Toast>(null);
 
@@ -187,8 +182,6 @@ export function DisplayProductInfo(keyProduct: string): JSX.Element {
               onChange={(e: ToggleButtonChangeEvent): void => {
                 setChecked(e.value);
                 if (e.value) {
-                  count.errors =
-                    'The product was successfully removed from the cart';
                   console.log(count.productId);
                   asyncUpdateCartProductId(count.productItemId, callback);
                   popUpMessage(PRODUCT_REMOVE, e.value);

--- a/src/components/Product.tsx
+++ b/src/components/Product.tsx
@@ -33,7 +33,6 @@ export const ProductItem = (data: ProductProjection): JSX.Element => {
   const navigate = useNavigate();
   //=========
   const [checked, setChecked] = useState<boolean>(false);
-  //const [visibleError, setVisibleError] = useState<boolean>(false); можно удалить??
   let keyProduct = '';
   const id = key;
   if (id) keyProduct = id;
@@ -44,9 +43,7 @@ export const ProductItem = (data: ProductProjection): JSX.Element => {
 
   // так понимаю эту функцию мы можем удалить, setVisibleError(true) вызывать напрямую
   // в на месте вызова callback
-  const callback = (delet: boolean, sumaItem: number): void => {
-    // setVisibleError(true);
-  };
+  const callback = (): void => {};
 
   const messagePopUp = useRef<Toast>(null);
 
@@ -99,20 +96,14 @@ export const ProductItem = (data: ProductProjection): JSX.Element => {
               if (!checked) {
                 setChecked(true);
                 popUpMessage(PRODUCT_REMOVE);
-                count.errors =
-                  'The product was successfully removed from the cart';
                 // функцию переделать посмотреть, нужен ли нам тут callback
                 asyncUpdateCartProductId(data.id, callback);
               } else {
                 setChecked(false);
                 popUpMessage(PRODUCT_ADD);
                 if (count.cartID) {
-                  count.errors = 'The product was successfully add in the cart';
-                  // callback(true, 0);
                   asyncAddItemCart(data.id);
                 } else {
-                  count.errors = 'The product was successfully add in the cart';
-                  // callback(true, 0);
                   cartUserDraft(data.id);
                 }
               }


### PR DESCRIPTION
1. Заменил функцию asyncCartDeleteID на asyncDeleteAllProductForCartID  теперь удаляется не корзина а весь товар из нее.
2. С вопросом по callback в DisplayProductInfo и Product почистил что можно теперь не всплывает модальное окно при входе в корзину из каталога и карты продукта, но callback выполнял раньше 2 задачи давал команду на вывод ошибки и передавал данные о количестве товара после его изменения, одну задачу убрали но вторая осталась. Чтобы убрать callback  совсем надо решать задачу передачи данных по количеству другим способом.